### PR TITLE
fixed error in rename android app name

### DIFF
--- a/lib/file_repository.dart
+++ b/lib/file_repository.dart
@@ -279,7 +279,8 @@ class FileRepository {
     }
     for (var i = 0; i < contentLineByLine!.length; i++) {
       if (contentLineByLine[i].contains('android:label=')) {
-        contentLineByLine[i] = '        android:label=\"$appName\"';
+        contentLineByLine[i] = contentLineByLine[i] = contentLineByLine[i].toString().replaceFirst(
+            RegExp(r'android:label="(.*?)"'), 'android:label="$appName"');
         break;
       }
     }


### PR DESCRIPTION
was replacing the entire line and causing an error in files with all parameters on one line