### PR TITLE
update CFBundleDisplayName while updating ios AppName

### DIFF
--- a/lib/file_repository.dart
+++ b/lib/file_repository.dart
@@ -233,6 +233,14 @@ class FileRepository {
         break;
       }
     }
+
+    for (var i = 0; i < contentLineByLine!.length; i++) {
+      if (contentLineByLine[i].contains('<key>CFBundleDisplayName</key>')) {
+        contentLineByLine[i + 1] = '\t<string>$appName</string>\r';
+        break;
+      }
+    }
+
     var writtenFile = await writeFile(
       filePath: iosInfoPlistPath,
       content: contentLineByLine.join('\n'),


### PR DESCRIPTION
Package obviously updates app name but forgets to update "CFBundleDisplayName". Since it effects to visible app name this PR is mandatory.

`--appname "New Test Package Name" --bundleId com.newtestpackagename`

Now you get this result:
![newstuff](https://user-images.githubusercontent.com/26818892/147282726-fc0f60f4-d57d-4633-b969-f5f567c0b846.png)

Instead of this:
![oldstuff](https://user-images.githubusercontent.com/26818892/147282723-763ec9c2-051e-4373-b0c1-3c847b556b7c.png)

