### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can change the bundleId and appName in following folders
 ## Installation
 
 ```
-pub global activate rename
+flutter pub global activate rename
 ```
 
 ## Default Usage
@@ -26,8 +26,8 @@ flutter project.
 
 _**Run this command inside your flutter project root.**_
 
-        pub global run rename --bundleId com.onatcipli.networkUpp
-        pub global run rename --appname "Network Upp"
+        flutter pub global run rename --bundleId com.onatcipli.networkUpp
+        flutter pub global run rename --appname "Network Upp"
 
 ## Custom Usage
 
@@ -39,11 +39,11 @@ you [add system cache bin directory to your path](https://dart.dev/tools/pub/cmd
 
 or
 
-        pub global run rename --appname yourappname --target macOS
+        flutter pub global run rename --appname yourappname --target macOS
 
 To target a specific platform use the "--target" option. e.g.
 
-        pub global run rename --bundleId com.example.android.app --target android
+        flutter pub global run rename --bundleId com.example.android.app --target android
 
 ## Parameters
 


### PR DESCRIPTION
You will encounter:
'command not found: pub'

Nowadays (due to Dart being supplied / integrated with / in Flutter now) suggested correct use of pub is to be called via the flutter or dart command, as mostly this package will be used in flutter projects rather than pure dart so in readme it should be 'flutter pub' rather 'pub'.