### PR TITLE
Replace wrong log text "Windows" to "Web" for "--target web"

### DIFF
--- a/lib/file_repository.dart
+++ b/lib/file_repository.dart
@@ -395,7 +395,7 @@ class FileRepository {
       filePath: windowsAppPath,
       content: contentLineByLine.join('\n'),
     );
-    logger.i('Windows appname changed successfully to : $appName');
+    logger.i('Web appname changed successfully to : $appName');
     return writtenFile;
   }
 


### PR DESCRIPTION
This micro MR fixes wrong log where it says `Windows` instead of `Web` when target is `web`.

<img width="866" alt="image" src="https://user-images.githubusercontent.com/8538686/195926655-f393d0e1-9ed5-4d9f-9197-46efbb8e10e1.png">