### PR TITLE
Cope with changed runner code in new flutter

### DIFF
--- a/lib/file_repository.dart
+++ b/lib/file_repository.dart
@@ -427,6 +427,11 @@ class FileRepository {
             contentLineByLine[i].replaceAllMapped(RegExp(r'CreateAndShow\(L"([^"]+")'), (match) { return 'CreateAndShow(L"$appName"'; });
         break;
       }
+      else if (contentLineByLine[i].contains('window.Create')) {
+        contentLineByLine[i] =
+            contentLineByLine[i].replaceAllMapped(RegExp(r'Create\(L"([^"]+")'), (match) { return 'Create(L"$appName"'; });
+        break;
+      }
     }
     await writeFile(
       filePath: windowsAppPath,


### PR DESCRIPTION
The latest flutter version 3.7.1 has changed startup code for the runner.cpp file.  This adds a case for that so the app rename will continue to work.
