### PR TITLE
feat: added support for kotlin dsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to the "Rename CLI Tool" project will be documented in this file.
 
+# 3.1.0
+- Added support for the new `build.gradle.kts` *Kotlin DSL* format alongside the existing `build.gradle` *Groovy* configuration. The project now supports **both** formats, maintaining full backward compatibility with legacy build scripts.
+
 # 3.0.2
 - Troubleshooting updated in readme
 

--- a/lib/platform_file_editors/abs_platform_file_editor.dart
+++ b/lib/platform_file_editors/abs_platform_file_editor.dart
@@ -1,14 +1,4 @@
-/// File: abs_platform_file_editor.dart
-/// Project: rename
-/// Author: Onat Cipli
-/// Created Date: 24.09.2023
-/// Description: This file defines the abstract class for PlatformFileEditors and its methods.
-
-import 'dart:io';
-
 import 'package:logger/logger.dart';
-import 'package:path/path.dart';
-import 'package:rename/custom_exceptions.dart';
 import 'package:rename/enums.dart';
 
 final Logger logger = Logger(
@@ -34,7 +24,7 @@ abstract class AbstractPlatformFileEditor {
   /// Returns: Future<String?>, a success message indicating the change in Bundle ID.
   Future<String?> setBundleId({required String bundleId}) async {
     var old = await getBundleId();
-    return 'rename has successfuly changed bundleId for ${platform.name.toUpperCase()}\n$old -> $bundleId';
+    return 'rename has successfully changed bundleId for ${platform.name.toUpperCase()}\n$old -> $bundleId';
   }
 
   /// Fetches the name of the application.
@@ -47,80 +37,6 @@ abstract class AbstractPlatformFileEditor {
   /// Returns: Future<String?>, a success message indicating the change in application name.
   Future<String?> setAppName({required String appName}) async {
     var old = await getAppName();
-    return 'rename has successfuly changed appname for ${platform.name.toUpperCase()}\n$old -> $appName';
-  }
-
-  /// Reads a file line by line.
-  /// Parameters:
-  /// - `filePath`: The path of the file to be read.
-  /// Returns: Future<List<String?>>, a list of lines in the file.
-  /// Throws [FileReadException] if there is an error reading the file.
-  Future<List<String?>> readFileAsLineByline({
-    required String filePath,
-  }) async {
-    try {
-      var fileAsString = await File(filePath).readAsString();
-      var fileContent = fileAsString.split('\n');
-      _checkFileExists(
-        fileContent: fileContent,
-        filePath: filePath,
-      );
-      return fileContent;
-    } catch (e) {
-      throw FileReadException(
-        filePath: filePath,
-        platform: platform,
-        details: e.toString(),
-      );
-    }
-  }
-
-  /// Writes the provided [content] to a file at the specified [filePath].
-  /// Parameters:
-  /// - `filePath`: The path of the file to be written to.
-  /// - `content`: The content to be written to the file.
-  /// Returns: Future<File>, the file with the written content.
-  /// Throws [FileWriteException] if there is an error writing to the file.
-  Future<File> writeFile({
-    required String filePath,
-    required String content,
-  }) async {
-    try {
-      return await File(filePath).writeAsString(content);
-    } catch (e) {
-      throw FileWriteException(
-        filePath: filePath,
-        platform: platform,
-        details: e.toString(),
-      );
-    }
-  }
-
-  /// Checks if a file exists by verifying that its content is not null or empty.
-  /// Parameters:
-  /// - `fileContent`: The content of the file.
-  /// - `filePath`: The path of the file.
-  /// Returns: bool, true if the file exists, false otherwise.
-  /// Throws [FileNotExistException] if the file does not exist.
-  bool _checkFileExists({
-    required List? fileContent,
-    required String filePath,
-  }) {
-    if (fileContent == null || fileContent.isEmpty) {
-      throw FileNotExistException(
-        filePath: filePath,
-        platform: platform,
-        details: 'File content is null or empty',
-      );
-    }
-    return true;
-  }
-
-  /// Converts a list of path segments into a platform-specific file path.
-  /// Parameters:
-  /// - `paths`: A list of path segments.
-  /// Returns: String, the platform-specific file path.
-  static String convertPath(List<String> paths) {
-    return joinAll(paths);
+    return 'rename has successfully changed appName for ${platform.name.toUpperCase()}\n$old -> $appName';
   }
 }

--- a/lib/platform_file_editors/ios_platform_file_editor.dart
+++ b/lib/platform_file_editors/ios_platform_file_editor.dart
@@ -8,16 +8,18 @@
 
 import 'package:rename/enums.dart';
 import 'package:rename/platform_file_editors/abs_platform_file_editor.dart';
+import 'package:rename/utils/files.dart';
 
 /// [IosPlatformFileEditor] is responsible for editing iOS platform files.
 /// Attributes:
 /// - [iosInfoPlistPath]: Path to the iOS Info.plist file.
 /// - [iosProjectPbxprojPath]: Path to the iOS project.pbxproj file.
 class IosPlatformFileEditor extends AbstractPlatformFileEditor {
-  String iosInfoPlistPath = AbstractPlatformFileEditor.convertPath(
+  static const _bundleIdentifierKey = 'PRODUCT_BUNDLE_IDENTIFIER';
+  String iosInfoPlistPath = convertPath(
     ['ios', 'Runner', 'Info.plist'],
   );
-  String iosProjectPbxprojPath = AbstractPlatformFileEditor.convertPath(
+  String iosProjectPbxprojPath = convertPath(
     ['ios', 'Runner.xcodeproj', 'project.pbxproj'],
   );
 
@@ -34,6 +36,7 @@ class IosPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = iosInfoPlistPath;
     var contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i]?.contains('<key>CFBundleName</key>') ?? false) {
@@ -53,10 +56,13 @@ class IosPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = iosProjectPbxprojPath;
     var contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
-      if (contentLineByLine[i]?.contains('PRODUCT_BUNDLE_IDENTIFIER') ??
-          false) {
+      final line = contentLineByLine[i];
+      final hasBundleIdentifier =
+          line?.contains(IosPlatformFileEditor._bundleIdentifierKey) ?? false;
+      if (hasBundleIdentifier) {
         return (contentLineByLine[i] as String).split('=').last.trim();
       }
     }
@@ -74,6 +80,7 @@ class IosPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = iosInfoPlistPath;
     List? contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i].contains('<key>CFBundleName</key>')) {
@@ -93,6 +100,7 @@ class IosPlatformFileEditor extends AbstractPlatformFileEditor {
     var writtenFile = await writeFile(
       filePath: filePath,
       content: contentLineByLine.join('\n'),
+      platform: platform,
     );
     return message;
   }
@@ -108,6 +116,7 @@ class IosPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = iosProjectPbxprojPath;
     List? contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i].contains('PRODUCT_BUNDLE_IDENTIFIER')) {
@@ -118,6 +127,7 @@ class IosPlatformFileEditor extends AbstractPlatformFileEditor {
     var writtenFile = await writeFile(
       filePath: filePath,
       content: contentLineByLine.join('\n'),
+      platform: platform,
     );
     return message;
   }

--- a/lib/platform_file_editors/linux_platform_file_editor.dart
+++ b/lib/platform_file_editors/linux_platform_file_editor.dart
@@ -6,6 +6,7 @@
 
 import 'package:rename/enums.dart';
 import 'package:rename/platform_file_editors/abs_platform_file_editor.dart';
+import 'package:rename/utils/files.dart';
 
 /// [LinuxPlatformFileEditor] is a class that extends [AbstractPlatformFileEditor].
 /// It is responsible for editing Linux platform files.
@@ -14,10 +15,10 @@ import 'package:rename/platform_file_editors/abs_platform_file_editor.dart';
 /// - [linuxCMakeListsPath]: Represents the path to the Linux CMakeLists.txt file.
 /// - [linuxAppCppPath]: Represents the path to the Linux my_application.cc file.
 class LinuxPlatformFileEditor extends AbstractPlatformFileEditor {
-  String linuxCMakeListsPath = AbstractPlatformFileEditor.convertPath(
+  String linuxCMakeListsPath = convertPath(
     ['linux', 'CMakeLists.txt'],
   );
-  String linuxAppCppPath = AbstractPlatformFileEditor.convertPath(
+  String linuxAppCppPath = convertPath(
     ['linux', 'my_application.cc'],
   );
 
@@ -37,6 +38,7 @@ class LinuxPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = linuxCMakeListsPath;
     var contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i]?.contains('set(BINARY_NAME') ?? false) {
@@ -56,6 +58,7 @@ class LinuxPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = linuxAppCppPath;
     var contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i]?.contains('kFlutterWindowTitle') ?? false) {
@@ -78,6 +81,7 @@ class LinuxPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = linuxCMakeListsPath;
     List? contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i].contains('set(BINARY_NAME')) {
@@ -89,6 +93,7 @@ class LinuxPlatformFileEditor extends AbstractPlatformFileEditor {
     await writeFile(
       filePath: filePath,
       content: contentLineByLine.join('\n'),
+      platform: platform,
     );
     return message;
   }
@@ -104,6 +109,7 @@ class LinuxPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = linuxAppCppPath;
     List? contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i].contains('kFlutterWindowTitle')) {
@@ -115,6 +121,7 @@ class LinuxPlatformFileEditor extends AbstractPlatformFileEditor {
     await writeFile(
       filePath: filePath,
       content: contentLineByLine.join('\n'),
+      platform: platform,
     );
     return message;
   }

--- a/lib/platform_file_editors/macos_platform_file_editor.dart
+++ b/lib/platform_file_editors/macos_platform_file_editor.dart
@@ -6,6 +6,7 @@
 
 import 'package:rename/enums.dart';
 import 'package:rename/platform_file_editors/abs_platform_file_editor.dart';
+import 'package:rename/utils/files.dart';
 
 /// [MacosPlatformFileEditor] is a class that extends [AbstractPlatformFileEditor].
 /// It is responsible for editing macOS platform files.
@@ -13,7 +14,7 @@ import 'package:rename/platform_file_editors/abs_platform_file_editor.dart';
 /// Attributes:
 /// - [macosAppInfoxprojPath]: Path to the macOS AppInfo.xcconfig file.
 class MacosPlatformFileEditor extends AbstractPlatformFileEditor {
-  String macosAppInfoxprojPath = AbstractPlatformFileEditor.convertPath(
+  String macosAppInfoxprojPath = convertPath(
     ['macos', 'Runner', 'Configs', 'AppInfo.xcconfig'],
   );
 
@@ -33,6 +34,7 @@ class MacosPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = macosAppInfoxprojPath;
     var contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i]?.contains('PRODUCT_NAME') ?? false) {
@@ -50,6 +52,7 @@ class MacosPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = macosAppInfoxprojPath;
     var contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i]?.contains('PRODUCT_BUNDLE_IDENTIFIER') ??
@@ -71,6 +74,7 @@ class MacosPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = macosAppInfoxprojPath;
     List? contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i].contains('PRODUCT_NAME')) {
@@ -82,6 +86,7 @@ class MacosPlatformFileEditor extends AbstractPlatformFileEditor {
     await writeFile(
       filePath: filePath,
       content: contentLineByLine.join('\n'),
+      platform: platform,
     );
     return message;
   }
@@ -97,6 +102,7 @@ class MacosPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = macosAppInfoxprojPath;
     List? contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i].contains('PRODUCT_BUNDLE_IDENTIFIER')) {
@@ -107,6 +113,7 @@ class MacosPlatformFileEditor extends AbstractPlatformFileEditor {
     await writeFile(
       filePath: filePath,
       content: contentLineByLine.join('\n'),
+      platform: platform,
     );
     return message;
   }

--- a/lib/platform_file_editors/web_platform_file_editor.dart
+++ b/lib/platform_file_editors/web_platform_file_editor.dart
@@ -8,6 +8,7 @@
 
 import 'package:rename/enums.dart';
 import 'package:rename/platform_file_editors/abs_platform_file_editor.dart';
+import 'package:rename/utils/files.dart';
 
 /// [WebPlatformFileEditor] is a class responsible for editing Web platform files.
 /// It extends the [AbstractPlatformFileEditor] class.
@@ -15,7 +16,7 @@ import 'package:rename/platform_file_editors/abs_platform_file_editor.dart';
 /// Attributes:
 /// - `webIndexPath`: Path to the Web index.html file.
 class WebPlatformFileEditor extends AbstractPlatformFileEditor {
-  String webIndexPath = AbstractPlatformFileEditor.convertPath(
+  String webIndexPath = convertPath(
     ['web', 'index.html'],
   );
 
@@ -35,11 +36,12 @@ class WebPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = webIndexPath;
     var contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
-      if (contentLineByLine[i]?.contains('<title>') ?? false) {
-        var match =
-            RegExp(r'<title>(.*?)</title>').firstMatch(contentLineByLine[i]!);
+      final line = contentLineByLine[i];
+      if (line?.contains('<title>') ?? false) {
+        var match = RegExp(r'<title>(.*?)</title>').firstMatch(line!);
         return match?.group(1)?.trim();
       }
     }
@@ -57,6 +59,7 @@ class WebPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = webIndexPath;
     List? contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i].contains('<title>') &&
@@ -69,6 +72,7 @@ class WebPlatformFileEditor extends AbstractPlatformFileEditor {
     var writtenFile = await writeFile(
       filePath: filePath,
       content: contentLineByLine.join('\n'),
+      platform: platform,
     );
     return message;
   }

--- a/lib/platform_file_editors/windows_platform_file_editor.dart
+++ b/lib/platform_file_editors/windows_platform_file_editor.dart
@@ -6,6 +6,7 @@
 
 import 'package:rename/enums.dart';
 import 'package:rename/platform_file_editors/abs_platform_file_editor.dart';
+import 'package:rename/utils/files.dart';
 
 /// [WindowsPlatformFileEditor] is a class responsible for editing Windows platform files.
 /// It extends the [AbstractPlatformFileEditor] class.
@@ -14,10 +15,10 @@ import 'package:rename/platform_file_editors/abs_platform_file_editor.dart';
 /// - `windowsAppPath`: Path to the Windows main.cpp file.
 /// - `windowsAppRCPath`: Path to the Windows Runner.rc file.
 class WindowsPlatformFileEditor extends AbstractPlatformFileEditor {
-  String windowsAppPath = AbstractPlatformFileEditor.convertPath(
+  String windowsAppPath = convertPath(
     ['windows', 'runner', 'main.cpp'],
   );
-  String windowsAppRCPath = AbstractPlatformFileEditor.convertPath(
+  String windowsAppRCPath = convertPath(
     ['windows', 'runner', 'Runner.rc'],
   );
 
@@ -34,15 +35,15 @@ class WindowsPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = windowsAppPath;
     var contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
-      if (contentLineByLine[i]?.contains('window.CreateAndShow') ?? false) {
-        var match = RegExp(r'CreateAndShow\(L"(.*?)"')
-            .firstMatch(contentLineByLine[i]!);
+      final line = contentLineByLine[i];
+      if (line?.contains('window.CreateAndShow') ?? false) {
+        var match = RegExp(r'CreateAndShow\(L"(.*?)"').firstMatch(line!);
         return match?.group(1)?.trim();
       } else if (contentLineByLine[i]?.contains('window.Create') ?? false) {
-        var match =
-            RegExp(r'Create\(L"(.*?)"').firstMatch(contentLineByLine[i]!);
+        var match = RegExp(r'Create\(L"(.*?)"').firstMatch(line!);
         return match?.group(1)?.trim();
       }
     }
@@ -57,11 +58,12 @@ class WindowsPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = windowsAppRCPath;
     var contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
-      if (contentLineByLine[i]?.contains('VALUE "InternalName"') ?? false) {
-        var match = RegExp(r'VALUE "InternalName", "(.*?)"')
-            .firstMatch(contentLineByLine[i]!);
+      final line = contentLineByLine[i];
+      if (line?.contains('VALUE "InternalName"') ?? false) {
+        var match = RegExp(r'VALUE "InternalName", "(.*?)"').firstMatch(line!);
         return match?.group(1)?.trim();
       }
     }
@@ -79,6 +81,7 @@ class WindowsPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = windowsAppPath;
     List? contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     var currentAppName = await getAppName();
     if (currentAppName != null) {
@@ -102,6 +105,7 @@ class WindowsPlatformFileEditor extends AbstractPlatformFileEditor {
     await writeFile(
       filePath: filePath,
       content: contentLineByLine.join('\n'),
+      platform: platform,
     );
     return 'App name set to $appName';
   }
@@ -117,6 +121,7 @@ class WindowsPlatformFileEditor extends AbstractPlatformFileEditor {
     final filePath = windowsAppRCPath;
     List? contentLineByLine = await readFileAsLineByline(
       filePath: filePath,
+      platform: platform,
     );
     for (var i = 0; i < contentLineByLine.length; i++) {
       if (contentLineByLine[i].contains('VALUE "InternalName"')) {
@@ -128,6 +133,7 @@ class WindowsPlatformFileEditor extends AbstractPlatformFileEditor {
     await writeFile(
       filePath: filePath,
       content: contentLineByLine.join('\n'),
+      platform: platform,
     );
     return message;
   }

--- a/lib/utils/files.dart
+++ b/lib/utils/files.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:path/path.dart';
+import 'package:rename/custom_exceptions.dart';
+import 'package:rename/enums.dart';
+
+/// Reads a file line by line.
+/// Parameters:
+/// - `filePath`: The path of the file to be read.
+/// Returns: Future<List<String?>>, a list of lines in the file.
+/// Throws [FileReadException] if there is an error reading the file.
+Future<List<String?>> readFileAsLineByline({
+  required String filePath,
+  required RenamePlatform platform,
+}) async {
+  try {
+    var fileAsString = await File(filePath).readAsString();
+    var fileContent = fileAsString.split('\n');
+    _checkFileExists(
+      fileContent: fileContent,
+      filePath: filePath,
+      platform: platform,
+    );
+    return fileContent;
+  } catch (e) {
+    throw FileReadException(
+      filePath: filePath,
+      platform: platform,
+      details: e.toString(),
+    );
+  }
+}
+
+/// Writes the provided [content] to a file at the specified [filePath].
+/// Parameters:
+/// - `filePath`: The path of the file to be written to.
+/// - `content`: The content to be written to the file.
+/// Returns: Future<File>, the file with the written content.
+/// Throws [FileWriteException] if there is an error writing to the file.
+Future<File> writeFile({
+  required String filePath,
+  required String content,
+  required RenamePlatform platform,
+}) async {
+  try {
+    return await File(filePath).writeAsString(content);
+  } catch (e) {
+    throw FileWriteException(
+      filePath: filePath,
+      platform: platform,
+      details: e.toString(),
+    );
+  }
+}
+
+/// Checks if a file exists by verifying that its content is not null or empty.
+/// Parameters:
+/// - `fileContent`: The content of the file.
+/// - `filePath`: The path of the file.
+/// Returns: bool, true if the file exists, false otherwise.
+/// Throws [FileNotExistException] if the file does not exist.
+bool _checkFileExists({
+  required List? fileContent,
+  required String filePath,
+  required RenamePlatform platform,
+}) {
+  if (fileContent == null || fileContent.isEmpty) {
+    throw FileNotExistException(
+      filePath: filePath,
+      platform: platform,
+      details: 'File content is null or empty',
+    );
+  }
+  return true;
+}
+
+/// Converts a list of path segments into a platform-specific file path.
+/// Parameters:
+/// - `paths`: A list of path segments.
+/// Returns: String, the platform-specific file path.
+String convertPath(List<String> paths) {
+  return joinAll(paths);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rename
 description: Helps you to change or rename your flutter project BundleId and AppName for Ios, Android, MacOS and Linux platforms
-version: 3.0.2
+version: 3.1.0
 homepage: https://github.com/onatcipli/rename.git
 
 environment:


### PR DESCRIPTION
### 🛠️ Description

This PR introduces support for the Kotlin DSL `build.gradle.kts` format in the Android project configuration. The Gradle setup has been updated to detect and work with both `build.gradle` (Groovy) and `build.gradle.kts` (Kotlin), ensuring backward compatibility with existing builds.

### ✅ Changes

- Added support for `build.gradle.kts`
- Preserved compatibility with `build.gradle`
- Included logic to detect and warn if both files are present, or if neither is found
- Updated changelog accordingly

### 🧪 Testing

- Verified build with both Groovy and Kotlin DSL scripts
- Ensured correct error messaging in case of conflicting or missing build files

### 🔗 Closes

Closes #58
Closes #59 
Closes #60 